### PR TITLE
fix: fixed broken tabs example path

### DIFF
--- a/apps/docs/pages/components/magic-tab-select.mdx
+++ b/apps/docs/pages/components/magic-tab-select.mdx
@@ -4,7 +4,7 @@
 
 - This component is used for animating the tab selection indicator.
 
-An example of this component is seen on the [Tabs example](/examples/tabs).
+An example of this component is seen on the [Tabs example](/applications/tabs).
 
 ### Props
 


### PR DESCRIPTION
Link to the tabs example in this page was broken : https://www.react-magic-motion.com/components/magic-tab-select . FIxed it in this PR. 