### PR TITLE
:bug: Fixed bug in context provider in `<MagicMotion/>`

### DIFF
--- a/packages/react-magic-motion/tests/index.tsx
+++ b/packages/react-magic-motion/tests/index.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useRef, cloneElement } from "react";
+import { forwardRef, useRef, cloneElement, createContext } from "react";
 import type { ReactElement, ReactNode } from "react";
 
 export function TestComponent({
@@ -47,4 +47,14 @@ export function cloneRootElem(rootElem: ReactElement): ReactNode {
     animate: { opacity: 1 },
     exit: { opacity: 0 },
   });
+}
+
+const ContextExample = createContext({});
+
+export function ContextProviderParent(): JSX.Element {
+  return (
+    <ContextExample.Provider value={{}}>
+      <div>Testing</div>
+    </ContextExample.Provider>
+  );
 }

--- a/packages/react-magic-motion/tests/magic-motion.test.tsx
+++ b/packages/react-magic-motion/tests/magic-motion.test.tsx
@@ -2,10 +2,16 @@ import { render } from "@testing-library/react";
 import { beforeAll, describe, expect, test, vi, afterEach } from "vitest";
 import "@testing-library/jest-dom";
 import { motion } from "framer-motion";
+import { Profiler } from "react";
 import { convertChildrenToMotionChildren } from "../utils/magic-animation";
 import { MagicExit } from "../magic-exit";
 import { MagicMotion } from "../magic-motion";
-import { TestComponent, ParentComponent, ForwardedRefParent } from ".";
+import {
+  TestComponent,
+  ParentComponent,
+  ForwardedRefParent,
+  ContextProviderParent,
+} from ".";
 
 describe("<MagicMotion> tests", () => {
   const consoleMock = vi
@@ -367,6 +373,29 @@ describe("<MagicMotion> tests", () => {
     render(
       <MagicMotion>
         <ForwardedRefParent />
+      </MagicMotion>
+    );
+  });
+
+  test("a context provider child", () => {
+    render(
+      <MagicMotion>
+        <ContextProviderParent />
+      </MagicMotion>
+    );
+  });
+
+  test("a react profiler child", () => {
+    render(
+      <MagicMotion>
+        <Profiler
+          id="ok"
+          onRender={() => {
+            return "ok";
+          }}
+        >
+          <div>test</div>
+        </Profiler>
       </MagicMotion>
     );
   });


### PR DESCRIPTION
## ✨ Overview
* Fixed bug with context provider causing an error when used as a children of a `<MagicMotion>` tag.
* Added testing for other special tags that cannot be converted to Motion tags, such as `<Profiler>` 
* Added unit tests for this

### Resolves #17 