### PR TITLE
chore: change url of todo list example

### DIFF
--- a/apps/docs/pages/components/index.mdx
+++ b/apps/docs/pages/components/index.mdx
@@ -7,7 +7,7 @@ import { Callout } from "nextra/components";
 - This component is the main component of the library.
 - All children of this component will have their layout changes automatically animated.
 
-An example of this component can be seen on the [To Do List example](/examples).
+An example of this component can be seen on the [To Do List example](/applications).
 
 <Callout type="warning" emoji="⚠️">
   All children of the `<MagicMotion />` component will have their css


### PR DESCRIPTION
Hello,

I was checking the doc for the first time, huge thanks for this amazing library.

I saw a wrong URL sending to **/examples** for the "Todo List Example" but now the url seems to be **/applications**